### PR TITLE
Performance Improvements

### DIFF
--- a/app/(default)/(faceted)/brand/[slug]/static/page.tsx
+++ b/app/(default)/(faceted)/brand/[slug]/static/page.tsx
@@ -13,4 +13,4 @@ export async function generateStaticParams() {
 }
 
 export const dynamic = 'force-static';
-export const revalidate = 600;
+export const revalidate = 3600;

--- a/app/(default)/(faceted)/category/[slug]/static/page.tsx
+++ b/app/(default)/(faceted)/category/[slug]/static/page.tsx
@@ -25,4 +25,4 @@ export async function generateStaticParams() {
 }
 
 export const dynamic = 'force-static';
-export const revalidate = 600;
+export const revalidate = 3600;

--- a/app/(default)/compare/_components/add-to-cart-form.tsx
+++ b/app/(default)/compare/_components/add-to-cart-form.tsx
@@ -34,7 +34,7 @@ export const AddToCartForm = ({
           <div className="flex items-center gap-3">
             <span>
               {quantity} {quantity === 1 ? 'Item' : 'Items'} added to{' '}
-              <Link className="font-semibold" href="/cart" prefetch={false}>
+              <Link className="font-semibold" href="/cart" prefetch={true}>
                 your cart
               </Link>
             </span>

--- a/app/(default)/product/[slug]/static/page.tsx
+++ b/app/(default)/product/[slug]/static/page.tsx
@@ -14,4 +14,4 @@ export async function generateStaticParams() {
 }
 
 export const dynamic = 'force-static';
-export const revalidate = 600;
+export const revalidate = 3600;

--- a/app/(default)/static/page.tsx
+++ b/app/(default)/static/page.tsx
@@ -3,4 +3,4 @@ import HomePage from '../page';
 export default HomePage;
 
 export const dynamic = 'force-static';
-export const revalidate = 600;
+export const revalidate = 3600;

--- a/app/api/revalidate/route/route.ts
+++ b/app/api/revalidate/route/route.ts
@@ -16,7 +16,7 @@ const handler = async (request: NextRequest) => {
 
   const node = await getRoute(pathname);
 
-  const expiryTime = Date.now() + 1000 * 60 * 30; // 30 minutes;
+  const expiryTime = Date.now() + 1000 * 60 * 60 * 12; // 12 hours;
 
   try {
     await kv.set(pathname, { node, expiryTime });

--- a/components/header/header-nav/base.tsx
+++ b/components/header/header-nav/base.tsx
@@ -36,7 +36,7 @@ export const BaseHeaderNav = ({
                 <NavigationMenuTrigger className="gap-1">
                   <>
                     <NavigationMenuLink asChild>
-                      <Link className="grow" href={category.path}>
+                      <Link className="grow" href={category.path} prefetch={true}>
                         {category.name}
                       </Link>
                     </NavigationMenuLink>
@@ -85,7 +85,7 @@ export const BaseHeaderNav = ({
               </>
             ) : (
               <NavigationMenuLink asChild>
-                <Link href={category.path}>{category.name}</Link>
+                <Link href={category.path} prefetch={true}>{category.name}</Link>
               </NavigationMenuLink>
             )}
           </NavigationMenuItem>

--- a/components/product-card/cart.tsx
+++ b/components/product-card/cart.tsx
@@ -47,7 +47,7 @@ export const Cart = ({ product }: { product: Partial<Product> }) => {
             <div className="flex items-center gap-3">
               <span>
                 {quantity} {quantity === 1 ? 'Item' : 'Items'} added to{' '}
-                <Link className="font-semibold" href="/cart" prefetch={false}>
+                <Link className="font-semibold" href="/cart" prefetch={true}>
                   your cart
                 </Link>
               </span>

--- a/components/product-card/index.tsx
+++ b/components/product-card/index.tsx
@@ -118,6 +118,7 @@ export const ProductCard = ({
             <Link
               className="focus:outline-none focus-visible:outline-2 focus-visible:outline-blue focus-visible:ring-0"
               href={product.path}
+              prefetch={true}
             >
               <span aria-hidden="true" className="absolute inset-0 bottom-20" />
               {product.name}

--- a/components/product-carousel/product-card.tsx
+++ b/components/product-carousel/product-card.tsx
@@ -110,6 +110,7 @@ export const ProductCard = ({
         <ProductCardInfoProductName>
           {product.path ? (
             <Link
+              prefetch={true}
               className="focus:outline focus:outline-4 focus:outline-offset-2 focus:outline-blue-primary/20 focus:ring-0"
               href={product.path}
             >


### PR DESCRIPTION
- Use `event.waitUntil()` on middleware revalidate path
- Bump revalidation timeline to 3600 seconds
- Prefetch cart after add-to-cart
- Bump KV revalidation time to 12h
- Remove storefront status check from middleware